### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/docs/UPDATE_ENVIRONMENT.md
+++ b/docs/UPDATE_ENVIRONMENT.md
@@ -8,7 +8,7 @@ The environment.yaml has been updated to include all necessary packages for your
 - **Python 3.11** (upgraded from 3.10)
 - **LangChain ecosystem** - Complete suite including experimental and langgraph
 - **Milvus support** - pymilvus for vector database
-- **AutoGen** - pyautogen for multi-agent systems
+- **AutoGen** - ag2 for multi-agent systems
 - **Google Gemini** - google-generativeai package
 - **Anthropic** - anthropic package for Claude API
 - **Development tools** - black, mypy, ruff, pylint

--- a/environment.yaml
+++ b/environment.yaml
@@ -55,7 +55,7 @@ dependencies:
       - cupy-cuda12x
       
       # AutoGen
-      - pyautogen
+      - ag2
       
       # Web frameworks
       - fastapi


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
